### PR TITLE
WIP: Add support for merging default resource params into hiera resources

### DIFF
--- a/lib/puppet/parser/functions/hiera_resources.rb
+++ b/lib/puppet/parser/functions/hiera_resources.rb
@@ -15,12 +15,20 @@ Puppet::Parser::Functions.newfunction(:hiera_resources) do |args|
     error("%s expects a hash as the 2nd argument; got %s" % [file_name, args[1].class]) unless args[1].is_a? Hash
   end
 
+  # Get a list of keys from args[1]
+  defaults_keys = args[1].keys
+
   if Puppet.version =~ /^4/
     call_function('hiera_hash', args).each do |type, resources|
       resources.each do |title, parameter|
-	if parameter == nil
-	  resources[title] = {}
-	end
+        if parameter == nil
+          resources[title] = {}
+        end
+
+        # Check if we need to add defaults for this resource type
+        if defaults_keys.include?(type)
+          resources[title].merge!(args[1][type])
+        end
       end
       # function_create_resources is no workie so we'll do this
       method = Puppet::Parser::Functions.function :create_resources
@@ -32,6 +40,11 @@ Puppet::Parser::Functions.newfunction(:hiera_resources) do |args|
       resources.each do |title, parameter|
         if parameter == nil
           resources[title] = {}
+        end
+        
+        # Check if we need to add defaults for this resource type
+        if defaults_keys.include?(type)
+          resources[title].merge!(args[1][type])
         end
       end
       # function_create_resources is no workie so we'll do this

--- a/lib/puppet/parser/functions/hiera_resources.rb
+++ b/lib/puppet/parser/functions/hiera_resources.rb
@@ -29,7 +29,7 @@ Puppet::Parser::Functions.newfunction(:hiera_resources) do |args|
 
         # Check if we need to add defaults for this resource type
         if defaults_keys.include?(type)
-          resources[title].merge!(args[1][type])
+          resources[title] = args[1][type].merge(resources[title])
         end
       end
       # function_create_resources is no workie so we'll do this
@@ -46,7 +46,7 @@ Puppet::Parser::Functions.newfunction(:hiera_resources) do |args|
         
         # Check if we need to add defaults for this resource type
         if defaults_keys.include?(type)
-          resources[title].merge!(args[1][type])
+          resources[title] = args[1][type].merge(resources[title])
         end
       end
       # function_create_resources is no workie so we'll do this

--- a/lib/puppet/parser/functions/hiera_resources.rb
+++ b/lib/puppet/parser/functions/hiera_resources.rb
@@ -11,12 +11,14 @@ Puppet::Parser::Functions.newfunction(:hiera_resources) do |args|
 
   error("%s requires 1 argument" % [file_name]) unless args.length >= 1
 
+  defaults_keys = []
+
   if args[1]
     error("%s expects a hash as the 2nd argument; got %s" % [file_name, args[1].class]) unless args[1].is_a? Hash
-  end
 
-  # Get a list of keys from args[1]
-  defaults_keys = args[1].keys
+    # Get a list of keys from args[1]
+    defaults_keys = args[1].keys
+  end
 
   if Puppet.version =~ /^4/
     call_function('hiera_hash', args).each do |type, resources|

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -9,3 +9,6 @@ test2:
 test3:
   notify:
     title 3:
+test defaults:
+  notify:
+    title defaults: {}

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -12,3 +12,7 @@ test3:
 test defaults:
   notify:
     title defaults: {}
+test defaults 2:
+  notify:
+    title defaults:
+      message: this is not the default message

--- a/spec/functions/hiera_resources_spec.rb
+++ b/spec/functions/hiera_resources_spec.rb
@@ -32,4 +32,14 @@ describe 'hiera_resources' do
   end
 
   it { should run.with_params('test').and_raise_error(Puppet::ParseError) }
+
+  it 'test_defaults with a notify and default merge' do
+    should run.with_params('test defaults',{'notify' => {'message' => 'This is a default message'}}).and_return(
+      {"notify" =>
+        {"title defaults" =>
+          {"message" => 'This is a default message'}
+        }
+      }
+    )
+  end
 end

--- a/spec/functions/hiera_resources_spec.rb
+++ b/spec/functions/hiera_resources_spec.rb
@@ -42,4 +42,14 @@ describe 'hiera_resources' do
       }
     )
   end
+
+  it 'test_defaults with a notify and default merge without over-writing' do
+    should run.with_params('test defaults 2',{'notify' => {'message' => 'This is a default message'}}).and_return(
+      {"notify" =>
+        {"title defaults" =>
+          {"message" => 'this is not the default message'}
+        }
+      }
+    )
+  end
 end


### PR DESCRIPTION
Add support for merging default resource params into hiera resources.

The logic behind this is to allow the merge of default resource parameters in a similar manner to the native Puppet `Resource { }` syntax. 
- [ ] Test
- [ ] Docs

Unknowns currently... 
- How to differentiate between a 'resource defaults' hash, and a 'default if non-existent' hash, as `hiera_hash` currently expects the 2nd arg to be a 'default if non-existent'.
